### PR TITLE
Fix downstream builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,14 @@ ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}
 ENV OS_GIT_MINOR=${CI_Y_VERSION}
 ENV OS_GIT_PATCH=${CI_Z_VERSION}
-ENV SOURCE_GIT_COMMIT=${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_COMMIT}
-ENV SOURCE_GIT_URL=${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_URL}
+ENV SOURCE_GIT_COMMIT=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT}
+ENV SOURCE_GIT_URL=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL}
 ENV REMOTE_SOURCE=${REMOTE_SOURCE:-.}
 
 
 WORKDIR  /go/src/github.com/log-file-metric-exporter
 COPY ${REMOTE_SOURCE} .
+ADD ${REMOTE_SOURCE}/Makefile .
 
 RUN make build
 
@@ -27,13 +28,13 @@ RUN chmod +x /usr/local/bin/log-file-metric-exporter.sh
 LABEL \
         io.k8s.display-name="OpenShift LogFileMetric Exporter" \
         io.k8s.description="OpenShift LogFileMetric Exporter component of OpenShift Cluster Logging" \
-        name="openshift/ose-log-file-metric-exporter" \
-        com.redhat.component="ose-log-file-metric-exporter-container" \
+        name="openshift/log-file-metric-exporter" \
+        com.redhat.component="log-file-metric-exporter-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Logging" \
-        io.openshift.build.commit.id=${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_COMMIT} \
-        io.openshift.build.source-location=${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_URL} \
-        io.openshift.build.commit.url=${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_URL}/commit/${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_COMMIT} \
+        io.openshift.build.commit.id=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT} \
+        io.openshift.build.source-location=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL} \
+        io.openshift.build.commit.url=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL}/commit/${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT} \
         version=${CI_CONTAINER_VERSION}
 
 CMD ["sh", "-c", "/usr/local/bin/log-file-metric-exporter.sh"]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,12 +1,12 @@
-#@follow_tag(openshift-golang-builder:1.14)
-FROM openshift-golang-builder:v1.14.4-9 AS builder
+#@follow_tag(openshift-golang-builder:1.15)
+FROM openshift-golang-builder:v1.15.7 AS builder
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}
 ENV OS_GIT_MINOR=${CI_Y_VERSION}
 ENV OS_GIT_PATCH=${CI_Z_VERSION}
-ENV SOURCE_GIT_COMMIT=${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_COMMIT}
-ENV SOURCE_GIT_URL=${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_URL}
+ENV SOURCE_GIT_COMMIT=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT}
+ENV SOURCE_GIT_URL=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL}
 ENV REMOTE_SOURCE=${REMOTE_SOURCE:-.}
 
 ## EXCLUDE BEGIN ##
@@ -29,13 +29,13 @@ RUN chmod +x /usr/local/bin/log-file-metric-exporter.sh
 LABEL \
         io.k8s.display-name="OpenShift LogFileMetric Exporter" \
         io.k8s.description="OpenShift LogFileMetric Exporter component of OpenShift Cluster Logging" \
-        name="openshift/ose-log-file-metric-exporter" \
-        com.redhat.component="ose-log-file-metric-exporter-container" \
+        name="openshift-logging/log-file-metric-exporter" \
+        com.redhat.component="log-file-metric-exporter-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Logging" \
-        io.openshift.build.commit.id=${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_COMMIT} \
-        io.openshift.build.source-location=${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_URL} \
-        io.openshift.build.commit.url=${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_URL}/commit/${CI_LOGFILEMETRIC_EXPORTER_UPSTREAM_COMMIT} \
+        io.openshift.build.commit.id=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT} \
+        io.openshift.build.source-location=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL} \
+        io.openshift.build.commit.url=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL}/commit/${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT} \
         version=${CI_CONTAINER_VERSION}
 
 CMD ["sh", "-c", "/usr/local/bin/log-file-metric-exporter.sh"]


### PR DESCRIPTION
This PR provides a couple of minor fixes for downstream builds namely:
1. Imagebuilder needs a separate `ADD` directive to copy the `Makefile`
2. The component name is `openshift-logging/log-file-metric-exporter` and **not** `openshift/log-file-metric-exporter`
3. The midstream `$CI_*` variables are expanded from the repo name thus `log-file-metric-exporter` becomes `*LOG_FILE_METRIC_EXPORTER*`