### PR TITLE
Sync with midstream dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### This is a generated file from Dockerfile.in ###
-#@follow_tag(openshift-golang-builder:1.15)
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.15)
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 
 ENV BUILD_VERSION=1.0.0
@@ -16,7 +16,7 @@ COPY ${REMOTE_SOURCE} .
 
 RUN make build
 
-#@follow_tag(openshift-ose-base:ubi8)
+#@follow_tag(registry.redhat.io/ubi8:latest)
 FROM registry.ci.openshift.org/ocp/4.7:base
 COPY --from=builder /go/src/github.com/log-file-metric-exporter/bin/log-file-metric-exporter  /usr/local/bin/.
 COPY --from=builder /go/src/github.com/log-file-metric-exporter/hack/log-file-metric-exporter.sh  /usr/local/bin/.

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,5 +1,5 @@
-#@follow_tag(openshift-golang-builder:1.15)
-FROM openshift-golang-builder:v1.15.7 AS builder
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.15)
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.15.14-202107291503.el8.git.1794691 AS builder
 
 ENV BUILD_VERSION=1.0.0
 ENV OS_GIT_MAJOR=1
@@ -18,8 +18,8 @@ COPY ${REMOTE_SOURCE} .
 
 RUN make build
 
-#@follow_tag(openshift-ose-base:ubi8)
-FROM openshift-ose-base:v4.0-202009120053.11408
+#@follow_tag(registry.redhat.io/ubi8:latest)
+FROM registry.redhat.io/ubi8:8.4-209
 COPY --from=builder /go/src/github.com/log-file-metric-exporter/bin/log-file-metric-exporter  /usr/local/bin/.
 COPY --from=builder /go/src/github.com/log-file-metric-exporter/hack/log-file-metric-exporter.sh  /usr/local/bin/.
 

--- a/origin-meta.yaml
+++ b/origin-meta.yaml
@@ -1,5 +1,5 @@
 from:
-- source: openshift-golang-builder\:v(?:[\.0-9\-]*).*
+- source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder\:v(?:[\.0-9\-]*).*
   target: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
-- source: openshift-ose-base\:v(?:[\.0-9\-]*)
+- source: registry.redhat.io/ubi8:8.(\d)-([\.0-9])*
   target: registry.ci.openshift.org/ocp/4.7:base


### PR DESCRIPTION
### Description
This PR synchronizes the midstream Dockerfiles (which use the RHEL-8 based golang builder) with upstream.

To address: https://issues.redhat.com/browse/LOG-1750

/cc @igor-karpukhin 
/assign @igor-karpukhin 