### PR TITLE
LOG-2122 Benchmark to verify no growth.

### DIFF
--- a/pkg/symnotify/symnotify_benchmark_test.go
+++ b/pkg/symnotify/symnotify_benchmark_test.go
@@ -1,0 +1,47 @@
+package symnotify_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"os"
+
+	"math/rand"
+
+	"github.com/log-file-metric-exporter/pkg/symnotify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// To check for memory growth run this benchmark for a longer time, e.g.
+// go test -memprofile=mem.prof -run X -bench BenchmarkStress -benchtime=5m
+func BenchmarkStress(b *testing.B) {
+	dir := b.TempDir()
+	w, err := symnotify.NewWatcher()
+	require.NoError(b, err)
+	require.NoError(b, w.Add(dir))
+	files := make([]*os.File, 512)
+	for i := 0; i < b.N; i++ {
+		n := rand.Intn(len(files))
+		f := files[n]
+		if f == nil { // Create if file not present
+			f, err = os.Create(filepath.Join(dir, fmt.Sprintf("log%d", n)))
+			files[n] = f
+			require.NoError(b, err)
+		} else {
+			p := rand.Intn(100)
+			if p < 10 { // Remove 10% of the time
+				_ = f.Close()
+				require.NoError(b, os.Remove(f.Name()))
+				files[n] = nil
+			} else { // Write 90% of the time
+				f.Write([]byte("hello\n"))
+			}
+		}
+		// Consume the event
+		e, err := w.Event()
+		require.NoError(b, err)
+		assert.Equal(b, f.Name(), e.Name)
+	}
+}


### PR DESCRIPTION
Added some extra test cases and benchmark to watch for growth.  Tested on a cluster for > 12hours: no long term growth.  Profile is choppy, and there is a slight upward trend for first hour but over 12 hours there is no growth trend.

LOG-2122 "logfilesmetricexporter" container memory leak

Accumulating time.Timer objects from the use of time.After.
Removed the timer as it is not required by the exporter.

/assign @jcantrill
/cc @pmoogi