### PR TITLE
LOG-2442: fix reporting of metrics for existing containers

### DIFF
--- a/pkg/logwatch/watcher_test.go
+++ b/pkg/logwatch/watcher_test.go
@@ -11,6 +11,8 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ViaQ/logerr/log"
 )
 
 const (
@@ -18,17 +20,25 @@ const (
 	data    = "hello\n"
 )
 
-func setup(t *testing.T) (watcher *Watcher, path string, labels LogLabels) {
+func setup(t *testing.T, initLog func(string)) (watcher *Watcher, path string, labels LogLabels) {
 	t.Helper()
 	dir, err := ioutil.TempDir("", t.Name())
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	watcher, err = New(dir)
+	t.Cleanup(func() {
+		log.V(4).Info("Running test cleanup...removing dir", "dir", dir)
+		_ = os.RemoveAll(dir)
+	})
 	require.NoError(t, err)
 	path = filepath.Join(dir, logname)
 	require.True(t, labels.Parse(path))
 	os.MkdirAll(filepath.Dir(path), 0700)
+	if initLog != nil {
+		initLog(path)
+	}
+	watcher, err = New(dir)
+	require.NoError(t, err)
 	go watcher.Watch()
+	t.Cleanup(func() { watcher.Close() })
 	return watcher, path, labels
 }
 
@@ -41,7 +51,7 @@ func getCounterValue(c prometheus.Counter) float64 {
 }
 
 func TestWatcherSeesFileChange(t *testing.T) {
-	w, path, l := setup(t)
+	w, path, l := setup(t, nil)
 
 	counter, err := w.metrics.GetMetricWithLabelValues(l.Namespace, l.Name, l.UUID, l.Container)
 	require.NoError(t, err)
@@ -61,4 +71,39 @@ func TestWatcherSeesFileChange(t *testing.T) {
 			return getCounterValue(counter) == 0
 		},
 		time.Second, time.Second/10, "%v != 0", len(data), getCounterValue(counter))
+}
+func TestWatcherSeesAndWatchesExistingFiles(t *testing.T) {
+	w, path, l := setup(t, func(path string) {
+		writeToFile(t, path)
+		require.NoError(t, ioutil.WriteFile(path, []byte(data), 0600))
+	})
+
+	counter, err := w.metrics.GetMetricWithLabelValues(l.Namespace, l.Name, l.UUID, l.Container)
+	require.NoError(t, err)
+	// assert we see the initial file size
+	assert.Eventually(t,
+		func() bool {
+			v := getCounterValue(counter)
+			log.V(3).Info("initial size", "counter", v)
+			return float64(len(data)) == v
+		},
+		time.Second, time.Second/10, "%v != %v", len(data), getCounterValue(counter))
+
+	writeToFile(t, path)
+	writeToFile(t, path)
+	// assert we see the change in the file size
+	assert.Eventually(t,
+		func() bool {
+			v := getCounterValue(counter)
+			log.V(3).Info("size after write", "counter", v)
+			return float64(3*len(data)) == v
+		},
+		time.Second, time.Second/10, "%v != %v", 3*len(data), getCounterValue(counter))
+}
+
+func writeToFile(t *testing.T, path string) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	require.NoError(t, err)
+	_, err = f.Write([]byte(data))
+	require.NoError(t, err)
 }


### PR DESCRIPTION
This PR:
* fixes watch of existing containers where the metrics were not reported for those that existed prior to the collector lifetime
* Adds fsnotify read events to multiple go routines to resolve error noticed from max events 
* Limits the number of concurrent read events to control memory growth
* sync the map to ensure concurrent reads/writes
*  is a follow-up fix to https://github.com/ViaQ/log-file-metric-exporter/pull/16

ref: https://issues.redhat.com/browse/LOG-2442

cc @alanconway @syedriko 