### PR TITLE
Bump go version to 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 ### This is a generated file from Dockerfile.in ###
-#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.15)
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.17)
 FROM registry.access.redhat.com/ubi8/go-toolset AS builder
 
-ENV BUILD_VERSION=1.0.0
+ENV BUILD_VERSION=1.1.0
 ENV OS_GIT_MAJOR=1
-ENV OS_GIT_MINOR=0
+ENV OS_GIT_MINOR=1
 ENV OS_GIT_PATCH=0
 ENV SOURCE_GIT_COMMIT=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT}
 ENV SOURCE_GIT_URL=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL}
@@ -36,7 +36,6 @@ LABEL \
         io.openshift.build.commit.id=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT} \
         io.openshift.build.source-location=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL} \
         io.openshift.build.commit.url=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL}/commit/${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT} \
-        version=v1.0.0
+        version=v1.1.0
 
 CMD ["sh", "-c", "/usr/local/bin/log-file-metric-exporter.sh"]
-

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,9 +1,9 @@
-#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.15)
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.15.14-202107291503.el8.git.1794691 AS builder
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.17)
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.17.5-202202101345.el8.gb1a57e0 AS builder
 
-ENV BUILD_VERSION=1.0.0
+ENV BUILD_VERSION=1.1.0
 ENV OS_GIT_MAJOR=1
-ENV OS_GIT_MINOR=0
+ENV OS_GIT_MINOR=1
 ENV OS_GIT_PATCH=0
 ENV SOURCE_GIT_COMMIT=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT}
 ENV SOURCE_GIT_URL=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL}
@@ -38,6 +38,6 @@ LABEL \
         io.openshift.build.commit.id=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT} \
         io.openshift.build.source-location=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL} \
         io.openshift.build.commit.url=${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_URL}/commit/${CI_LOG_FILE_METRIC_EXPORTER_UPSTREAM_COMMIT} \
-        version=v1.0.0
+        version=v1.1.0
 
 CMD ["sh", "-c", "/usr/local/bin/log-file-metric-exporter.sh"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/log-file-metric-exporter
 
-go 1.15
+go 1.17
 
 require (
 	github.com/ViaQ/logerr v1.0.9
@@ -9,5 +9,18 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.33.0
 	github.com/stretchr/testify v1.4.0
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-logr/logr v0.2.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
 	golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
This PR updates the golang version to 1.17 and the version number to 1.1.0.

`io/fs` is not available until 1.16 and thus cannot build. (https://github.com/Red-GV/log-file-metric-exporter/blob/main/pkg/symnotify/symnotify.go#L7)

/cc @jcantrill 