### PR TITLE
fix(metrics): add HTTP server timeouts to prevent Slowloris DoS (LOG-9712)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	logv2 "github.com/ViaQ/logerr/v2/log"
 	log "github.com/ViaQ/logerr/v2/log/static"
@@ -208,9 +209,13 @@ func main() {
 
 	// Build a server:
 	httpServer := http.Server{
-		Addr:         addr,
-		TLSConfig:    &tlsConfig,
-		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)), // disable HTTP/2
+		Addr:              addr,
+		TLSConfig:         &tlsConfig,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		TLSNextProto:      make(map[string]func(*http.Server, *tls.Conn, http.Handler)), // disable HTTP/2
 	}
 	handler := http.Handler(promhttp.Handler())
 	if secureMetrics {


### PR DESCRIPTION
### Description
Set `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, and `IdleTimeout` on the metrics `http.Server` to prevent connection-exhaustion attacks from holding goroutines and file descriptors indefinitely.

JIRA: https://redhat.atlassian.net/browse/LOG-9712

/assign @jcantrill 
/cc @Clee2691 